### PR TITLE
Ошибка при попытке обновить некоторые торренты с rutor.org

### DIFF
--- a/updatorr/tracker_handlers/handler_rutor.py
+++ b/updatorr/tracker_handlers/handler_rutor.py
@@ -14,7 +14,7 @@ class RutorHandler(GenericPublicTrackerHandler):
         page_links = self.find_links(page_html)
         download_link = None
         for page_link in page_links:
-            if linkToFind in page_link:
+            if linkToFind in page_link.decode(errors="ignore"):
                 download_link = page_link
                 break
         return download_link


### PR DESCRIPTION
в логе сервера:

UnicodeDecodeError: 'ascii' codec can't decode byte 0xd0 in position ordinal not in range(128):

Причина в том, что некоторые линки на странице содержат utf-8 символы в href.
Это левые линки, не имеющие отношения к файлу торрента, так что я просто добавил .decode(errors=ignore) к url.
